### PR TITLE
fix ENOENT when installing module

### DIFF
--- a/bin/fetch.js
+++ b/bin/fetch.js
@@ -74,7 +74,7 @@ const awaitWritten = (stream, path) => {
             if (!dirs[dir]) {
                 dirs[dir] = promisify(fs.stat)(dir)
                     .catch(() => null)
-                    .then(exists => exists || promisify(fs.mkdir)(dir));
+                    .then(exists => exists || promisify(fs.mkdir)(dir, { recursive: true }));
             }
             await dirs[dir];
             await promisify(fs.writeFile)(resolve(dir, `${airport.icao}.json`), JSON.stringify(airport), {flag:"w+"});

--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   ],
   "main": "index.js",
   "engines": {
-    "node": ">=10"
+    "node": ">=10.12.0"
   },
   "dependencies": {
     "scramjet": "^4.34.4"


### PR DESCRIPTION
Installing the module with `npm install -s openflights-cached` will cause errors:

```
Error: ENOENT: no such file or directory, mkdir '/home/xyz/xyz-package/node_modules/openflights-cached/dist/icaos/A'
```

`dist/icaos` directory is not available in the package downloaded from npm, this might be the cause of the error. Using recursive option added in node 10.12.0 to create intermediate directories seems to fix it.