### PR TITLE
fix: ensure dist folder exists before downloading and writing files

### DIFF
--- a/bin/fetch.js
+++ b/bin/fetch.js
@@ -60,6 +60,11 @@ const awaitWritten = (stream, path) => {
 
     const dirs = {};
 
+    const distDir = resolve(__dirname, '../dist');
+    if (!fs.existsSync(distDir)) {
+        fs.mkdirSync(distDir);
+    }
+
     return Promise.all([
         awaitWritten(stream.pipe(new DataStream({}), {}).toJSONArray(), "../dist/array.json"),
         awaitWritten(stream.pipe(new DataStream({}), {}).filter(item => item.iata).toJSONArray(


### PR DESCRIPTION
### Motivation

I ran into the same issue as mentioned in https://github.com/signicode/openflights-cached/issues/10 with an error message to the effect of:

> (node:6213) UnhandledPromiseRejectionWarning: Error: ENOENT: no such file or directory, open '/Users/username/myproject/node_modules/openflights-cached/dist/array.json'

After investigating, the root cause of this issue is that the `dist` directory does not seem to get packaged in the NPM/Yarn bundle, and as a result, when we try to run `bin/build.js`, it can't create `dist/array.json` as the `dist` directory doesn't exist yet.

(It seems like NPM, when bundling the package, happened to exclude the dist folder because it only had hidden files (i.e. `.keep`). I verified that by running:)

```
curl https://registry.npmjs.org/openflights-cached/-/openflights-cached-1.3.14.tgz | tar -x
ls -l package

total 88
-rw-r--r--  1 peter  staff  1066 Oct 26  1985 LICENSE
-rw-r--r--  1 peter  staff  5076 Oct 26  1985 README.md
-rw-r--r--  1 peter  staff    47 Oct 26  1985 array.js
drwxr-xr-x  3 peter  staff    96 Oct 12 13:25 bin
-rw-r--r--  1 peter  staff    46 Oct 26  1985 iata.js
-rw-r--r--  1 peter  staff    51 Oct 26  1985 iata2icao.js
-rw-r--r--  1 peter  staff    46 Oct 26  1985 icao.js
-rw-r--r--  1 peter  staff    47 Oct 26  1985 icaos.js
-rw-r--r--  1 peter  staff  1078 Oct 26  1985 index.js
-rw-r--r--  1 peter  staff   225 Oct 26  1985 jsconfig.json
-rw-r--r--  1 peter  staff  1064 Oct 26  1985 package.json
drwxr-xr-x  3 peter  staff    96 Oct 12 13:25 test
```

### Changes

- Add commands to make sure that the dist directory exists before we try to download/write to files in the directory

### Testing

Ran:

```sh
rm -rf dist
npm run postinstall
```

and verified that it ran without any errors (it previously would give the above error)
